### PR TITLE
Speed up container run

### DIFF
--- a/commit0/harness/docker_utils.py
+++ b/commit0/harness/docker_utils.py
@@ -244,7 +244,7 @@ def cleanup_container(
     try:
         if container:
             log_info(f"Attempting to stop container {container.name}...")
-            container.stop(timeout=15)
+            container.kill()
     except Exception as e:
         log_error(
             f"Failed to stop container {container.name}: {e}. Trying to forcefully kill..."

--- a/commit0/harness/spec.py
+++ b/commit0/harness/spec.py
@@ -156,7 +156,7 @@ def make_eval_script_list(instance: RepoInstance, repo_directory: str) -> list[s
         f"git fetch {origin_name}",
         "git checkout {commit_id}",
         "git status",
-        f"{instance['test']['test_cmd']} --json-report --json-report-file=report.json {{test_ids}}",
+        f"uv run {instance['test']['test_cmd']} --json-report --json-report-file=report.json {{test_ids}}",
         f"git checkout {instance['base_commit']}",
         f"git remote remove {origin_name}",
         "git status",


### PR DESCRIPTION
Send the SIGKILL signal right after the pytest is complete instead of waiting for a few seconds.